### PR TITLE
Remove outdated CHANGELOG

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,0 @@
-2014-04-17 11:35:25 +0200	Bug fix (PS 1.5): ps_version_compliancy removed
-2014-03-24 15:22:14 +0100	/ MO pagesnotfound : ps_versions_compliancy added
-2014-03-20 14:35:27 +0100	Initial commit


### PR DESCRIPTION
I suggest to remove CHANGELOG file because it is not up-to-date and the project is small enough so git history is easily readable, thus a CHANGELOG file is not needed.