### PR TITLE
Use defined() with quotes is not optional

### DIFF
--- a/pagesnotfound.php
+++ b/pagesnotfound.php
@@ -48,7 +48,7 @@ class PagesNotFound extends Module
 
 	public function install()
 	{
-		if (defined(_PS_VERSION_) && version_compare(_PS_VERSION_, '1.5.0.1', '>=')) {
+		if (defined('_PS_VERSION_') && version_compare(_PS_VERSION_, '1.5.0.1', '>=')) {
 			$hookName = 'displayTop';
 		} else {
 			$hookName = 'top';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use defined() with quotes, they're not optional. 
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25002
| How to test?      | Look at the code is sufficient.
| Possible impacts? | None.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
