### PR TITLE
Do not use hook AdminStatsModules alias, use displayAdminStatsModules & Bump version to 2.0.2

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>pagesnotfound</name>
 	<displayName><![CDATA[Pages not found]]></displayName>
-	<version><![CDATA[2.0.1]]></version>
+	<version><![CDATA[2.0.2]]></version>
 	<description><![CDATA[Displays the pages requested by your visitors that have not been found.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[analytics_stats]]></tab>

--- a/pagesnotfound.php
+++ b/pagesnotfound.php
@@ -35,7 +35,7 @@ class PagesNotFound extends Module
 	{
 		$this->name = 'pagesnotfound';
 		$this->tab = 'analytics_stats';
-		$this->version = '2.0.1';
+		$this->version = '2.0.2';
 		$this->author = 'PrestaShop';
 		$this->need_instance = 0;
 
@@ -50,7 +50,7 @@ class PagesNotFound extends Module
 	{
 		if (!parent::install()
             || !$this->registerHook('displayTop')
-            || !$this->registerHook('AdminStatsModules')
+            || !$this->registerHook('displayAdminStatsModules')
         ) {
 			return false;
         }
@@ -99,7 +99,7 @@ class PagesNotFound extends Module
 		return $pages;
 	}
 
-	public function hookAdminStatsModules()
+	public function hookDisplayAdminStatsModules()
 	{
 		if (Tools::isSubmit('submitTruncatePNF'))
 		{

--- a/upgrade/upgrade-2.0.2.php
+++ b/upgrade/upgrade-2.0.2.php
@@ -1,0 +1,33 @@
+
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+/**
+ * @param Module $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_0_2$module)
+{
+    $module->unregisterHook('AdminStatsModules');
+    $module->registerHook('displayAdminStatsModules');
+
+    return true;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Do not use hook AdminStatsModules alias, use displayAdminStatsModules
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | n/d
| Possible impacts? | n/d

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
