### PR TITLE
Add stacking responsive table for mobile screen

### DIFF
--- a/pagesnotfound.php
+++ b/pagesnotfound.php
@@ -103,6 +103,8 @@ class PagesNotFound extends Module
 
     public function hookDisplayAdminStatsModules()
     {
+	$this->context->controller->addCSS($this->_path . 'views/stacking_responsive.css');
+	    
         if (Tools::isSubmit('submitTruncatePNF')) {
             Db::getInstance()->execute('TRUNCATE `' . _DB_PREFIX_ . 'pagenotfound`');
             $this->html .= '<div class="alert alert-warning"> ' . $this->trans('The "pages not found" cache has been emptied.', [], 'Modules.Pagesnotfound.Admin') . '</div>';
@@ -137,13 +139,19 @@ class PagesNotFound extends Module
 
         $pages = $this->getPages();
         if (count($pages)) {
+            $title_page = $this->trans('Page', [], 'Modules.Pagesnotfound.Admin');
+            $title_referer = $this->trans('Referrer', [], 'Modules.Pagesnotfound.Admin');
+            $title_counter = $this->trans('Counter', [], 'Modules.Pagesnotfound.Admin');
+
             $this->html .= '
+                    <div class="table__wrapper">
 			<table class="table">
 				<thead>
 					<tr>
-						<th><span class="title_box active">' . $this->trans('Page', [], 'Modules.Pagesnotfound.Admin') . '</span></th>
-						<th><span class="title_box active">' . $this->trans('Referrer', [], 'Modules.Pagesnotfound.Admin') . '</span></th>
-						<th><span class="title_box active">' . $this->trans('Counter', [], 'Modules.Pagesnotfound.Admin') . '</span></th>
+					        <th scope="row"></th>
+						<th scope="col"><span class="title_box active">' . $title_page . '</span></th>
+						<th scope="col"><span class="title_box active">' . $title_referer . '</span></th>
+						<th scope="col"><span class="title_box active">' . $title_counter . '</span></th>
 					</tr>
 				</thead>
 				<tbody>';
@@ -152,16 +160,18 @@ class PagesNotFound extends Module
                     if ($hr != 'nb') {
                         $this->html .= '
 						<tr>
-							<td><a href="' . $ru . '-admin404">' . wordwrap($ru, 30, '<br />', true) . '</a></td>
-							<td><a href="' . Tools::getProtocol() . $hr . '">' . wordwrap($hr, 40, '<br />', true) . '</a></td>
-							<td>' . $counter . '</td>
+						        <th scope="row"></th>
+							<td data-header="' . $title_page . '"><a href="' . $ru . '-admin404">' . wordwrap($ru, 30, '<br />', true) . '</a></td>
+							<td data-header="' . $title_referer . '"><a href="' . Tools::getProtocol() . $hr . '">' . wordwrap($hr, 40, '<br />', true) . '</a></td>
+							<td data-header="' . $title_counter . '">' . $counter . '</td>
 						</tr>';
                     }
                 }
             }
             $this->html .= '
 				</tbody>
-			</table>';
+			</table>
+		    </div>';
         } else {
             $this->html .= '<div class="alert alert-warning"> ' . $this->trans('No "page not found" issue registered for now.', [], 'Modules.Pagesnotfound.Admin') . '</div>';
         }

--- a/views/css/stacking_responsive.css
+++ b/views/css/stacking_responsive.css
@@ -1,0 +1,106 @@
+.table__wrapper {
+  width: 100%;
+}
+
+.table__wrapper .table {
+  width: 100%;
+  max-width: 100%;
+}
+
+
+/* ------- Presentational Formatting --------- */
+
+.table {
+  border: 1px solid #f0f0f0;
+  border-collapse: collapse;
+}
+
+.table tr {
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.table thead tr {
+  border-bottom: 2px solid #f0f0f0;
+}
+
+.table td,
+.table th {
+  padding: .5em;
+}
+
+.table th {
+  text-align: left;
+}
+
+@media screen and (max-width:768px) {
+  .table {
+    margin: 0 auto;
+    width: 100%;
+    border-spacing: 0;
+  }
+  .table thead {
+    position: absolute;
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 0;
+    border: 0;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+  }
+  .table tbody,
+  .table tr,
+  .table th,
+  .table td {
+    display: block;
+    padding: 0;
+    text-align: left;
+    white-space: normal;
+  }
+  .table tr td,
+  .table tr th {
+    padding: 2em 1em;
+    vertical-align: middle;
+    overflow: hidden;
+    position: relative;
+    vertical-align: top;
+    border: 1px solid #EDF0F1;
+    border-top: none;
+    width: 100%;
+    white-space: normal;
+  }
+  .table th[scope="row"] {
+    width: 100%;
+    height: 0.5em;
+    text-align: center;
+    display: block;
+    background-color: #B3BFC6;
+    margin: 0 auto;
+    padding: 0;    
+  }
+  .table td[data-header]:before {
+    content: attr(data-header);
+    display: block;
+    float: left;
+    width: 20%;
+    color: #000000;
+    font-weight: bold;
+    text-align: left;
+  }
+  .table td[data-header] > * {
+    display: block;
+    width: 80%;
+    float: right;
+    clear: right;
+    padding-left: 1em;
+    margin-top: 0;        
+  }
+  .table td[data-header]:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 20%;    
+    padding-bottom: 200%;
+    display: block;            
+  }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Use [Stacking Responsive Table](https://codepen.io/WebAdvanced/pen/MKqJeB) to solve responsive issue with listing table in stats modules.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27294. Related to PrestaShop/PrestaShop#27256
| How to test?  | Apply this PR changes, then check BO > SELL > Stats > Pages Not Found listing in different screen sizes <br>Below is PagesNotFound listing on 384px-wide screen <br> ![pagesnotfound_listing_cards](https://user-images.githubusercontent.com/3759923/220603385-e20107e3-06bb-4d62-af45-89d20c046990.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
