### PR TITLE
Fix: SQL queries using NOW() rely on MySQL timezone instead of shop timezone

### DIFF
--- a/pagesnotfound.php
+++ b/pagesnotfound.php
@@ -200,7 +200,7 @@ class PagesNotFound extends Module
                 Db::getInstance()->execute(
                     '
 		    INSERT INTO `' . _DB_PREFIX_ . 'pagenotfound` (`request_uri`, `http_referer`, `date_add`, `id_shop`, `id_shop_group`)
-		    VALUES (\'' . pSQL($request_uri) . '\', \'' . pSQL($http_referer) . '\', NOW(), ' . (int) $this->context->shop->id . ', ' . (int) $this->context->shop->id_shop_group . ')
+		    VALUES (\'' . pSQL($request_uri) . '\', \'' . pSQL($http_referer) . '\', \'' . date('Y-m-d H:i:s') . '\', ' . (int) $this->context->shop->id . ', ' . (int) $this->context->shop->id_shop_group . ')
 		    '
                 );
             }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | The 404 page log INSERT used \`NOW()\` to store \`date_add\`, which relies on the MySQL server timezone (UTC by default). Replaced with PHP's \`date('Y-m-d H:i:s')\` so the shop's configured timezone is used.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | Related to PrestaShop/PrestaShop#30828
| Related PRs       | PrestaShop/PrestaShop#41596
| Sponsor company   | PrestaShop SA

---
**Related CI issue:** #43